### PR TITLE
feat: remove source maps in production builds to optimize output. Also provide changeset for minor version bump.

### DIFF
--- a/.changeset/bright-searches-happen.md
+++ b/.changeset/bright-searches-happen.md
@@ -1,0 +1,5 @@
+---
+'scripts': minor
+---
+
+Add global search modal support to the main scripts bundle and clean up production source map output.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 
 # Build outputs
 # Note: packages/scripts/dist/ is NOT ignored - needed for jsdelivr CDN
+packages/scripts/dist/**/*.map
 packages/code-components/dist/
 build/
 *.tsbuildinfo

--- a/packages/scripts/bin/build.js
+++ b/packages/scripts/bin/build.js
@@ -1,7 +1,7 @@
 import process from 'node:process';
 
 import * as esbuild from 'esbuild';
-import { readdirSync } from 'fs';
+import { readdirSync, rmSync } from 'fs';
 import { join, sep } from 'path';
 
 // Config output
@@ -38,6 +38,7 @@ const context = await esbuild.context(buildOptions);
 
 // Build files in prod
 if (PRODUCTION) {
+  removeSourceMaps(BUILD_DIRECTORY);
   await context.rebuild();
   context.dispose();
 }
@@ -96,4 +97,28 @@ function logServedFiles() {
     .filter(Boolean);
 
   globalThis.console.table(filesInfo);
+}
+
+/**
+ * Removes dev-only source maps before production builds.
+ * @param {string} dirPath
+ */
+function removeSourceMaps(dirPath) {
+  try {
+    const files = readdirSync(dirPath, { withFileTypes: true });
+
+    for (const file of files) {
+      const path = join(dirPath, file.name);
+
+      if (file.isDirectory()) {
+        removeSourceMaps(path);
+      } else if (path.endsWith('.map')) {
+        rmSync(path);
+      }
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
- keep sourcemaps out of prod.
- changeset for minor version bump (forgotten in global search PR)