### PR TITLE
feat: add empty-state message for no upcoming sessions in Pro template

### DIFF
--- a/.changeset/pro-template-empty-state.md
+++ b/.changeset/pro-template-empty-state.md
@@ -1,0 +1,7 @@
+---
+"scripts": patch
+---
+
+Show a no-upcoming-sessions message on Pro template pages.
+
+When the flatlist has no future session dates, the template page now displays an empty-state message in the current `#time-slot` markup.


### PR DESCRIPTION
changeset for no upcoming session