### PR TITLE
Fix Socket Security scan memory resource constraints

### DIFF
--- a/.github/workflows/socket_reachability.yml
+++ b/.github/workflows/socket_reachability.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   socket-security:
     name: Socket Security Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 120
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
           # Build reachability flags if enabled
           REACH_FLAGS=""
           if [[ "${{ github.event.inputs.enable_reachability }}" != "false" ]]; then
-            REACH_FLAGS="--reach --reach-memory-limit 16384 --reach-timeout 3600"
+            REACH_FLAGS="--reach --reach-memory-limit 32768 --reach-timeout 3600"
             echo "Reachability analysis enabled"
           fi
 


### PR DESCRIPTION
## Summary
Fixes Socket Security Scan timeouts caused by insufficient memory for reachability analysis.

## Problem
The Socket scan was timing out after 6+ minutes during reachability analysis of `packages/code-components`. The runner was being shut down before the scan could complete, causing the job to fail with:
```
##[error]The runner has received a shutdown signal.
```

## Changes
- **Runner**: Upgraded from `ubuntu-latest` (7GB) to `ubuntu-latest-8-cores` (32GB RAM)
- **Memory limit**: Increased from 16GB to 32GB (`--reach-memory-limit 32768`)

This matches the same fix applied in webflow/infrastructure#6301 which resolved identical timeout issues.

## References
- Same fix in infrastructure repo: https://github.com/webflow/infrastructure/pull/6301
- Socket sizing guidance: https://docs.socket.dev/docs/full-application-reachability
- Failed run: https://github.com/webflow/webflow-university/actions/runs/27594315200

## Testing
The workflow can be manually triggered via workflow_dispatch to validate the fix.