### PR TITLE
Fix: revert to ubuntu-latest runner (8-core not available)

### DIFF
--- a/.github/workflows/socket_reachability.yml
+++ b/.github/workflows/socket_reachability.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   socket-security:
     name: Socket Security Scan
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
           # Build reachability flags if enabled
           REACH_FLAGS=""
           if [[ "${{ github.event.inputs.enable_reachability }}" != "false" ]]; then
-            REACH_FLAGS="--reach --reach-memory-limit 32768 --reach-timeout 3600"
+            REACH_FLAGS="--reach --reach-memory-limit 6144 --reach-timeout 1800"
             echo "Reachability analysis enabled"
           fi
 


### PR DESCRIPTION
## Summary
Reverts the runner from `ubuntu-latest-8-cores` to `ubuntu-latest` because the 8-core runner is not available for this repository.

## Problem
PR #53 configured the workflow to use `ubuntu-latest-8-cores`, but this runner type is not available, causing jobs to queue indefinitely without starting.

**Evidence:** Job has been queued for 40+ minutes without starting:
https://github.com/webflow/webflow-university/actions/runs/27643092845/job/81747946037

## Changes
- **Runner**: `ubuntu-latest-8-cores` → `ubuntu-latest` (7GB RAM available)
- **Memory limit**: 32768 MB → 6144 MB (6GB, leaving 1GB for system overhead)
- **Timeout**: 3600s (60 min) → 1800s (30 min) to fail faster if stuck

## Why these limits?
- Standard `ubuntu-latest` runners have ~7GB RAM
- Setting memory limit to 6GB leaves headroom for system processes
- Reduced timeout prevents long hangs and runner shutdowns

## Testing
The workflow will start immediately instead of queuing indefinitely.